### PR TITLE
Quell linter target issue

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@ethereumjs/config-tsc",
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "compilerOptions": {
+    "target": "es5"
+  }
 }


### PR DESCRIPTION
On my machine I get a linter issue because `get` is only available to es5+ targets. This PR modifies the `tsconfig.json` to make sure that the build targets es5.